### PR TITLE
Use hlexists() to detect vimple highlight groups

### DIFF
--- a/autoload/vimple.vim
+++ b/autoload/vimple.vim
@@ -116,11 +116,9 @@ function! vimple#echoc(data)
 endfunction
 
 function! s:vimple_highlight(name, attrs)
-  try
-    silent exe "hi ".a:name
-  catch /^Vim\%((\a\+)\)\=:E411/
+  if !hlexists(a:name)
     silent exe "hi ".a:name." ".a:attrs
-  endtry
+  endif
 endfunction
 
 " Solarized inspired default colours...


### PR DESCRIPTION
Prior to Vim 7.2.265, using `:silent` in a `:try/:catch` would cause Vim's messages area to remain "silent".  Using `hlexists()` instead of a `:try/:catch` resolves this issue and is more straight forward.
