### PR TITLE
Fix SpellSuggest demo

### DIFF
--- a/autoload/list.vim
+++ b/autoload/list.vim
@@ -65,6 +65,54 @@ function! list#zip(a, b, ...)
     exe "return r + a:b[" . n . ":]"
   endif
 endfunction "}}}1
+"
+" split list into count-element sublists
+function! list#split(list, count)
+  let lst = deepcopy(a:list)
+  let len = len(lst)
+  let cnt = a:count
+  let newlists = []
+  for idx in range(0, len, cnt)
+    if idx < len
+      if (cnt - 1) > len(lst)
+        let cnt = len(lst)
+      endif
+      call add(newlists, remove(lst, 0, (cnt - 1)))
+    endif
+  endfor
+  return newlists
+endfunc
+
+" split list into cols sublists and join with colsep=\t
+" list#lspread(list, cols, colsep="\t")
+function! list#lspread(list, cols, ...)
+  let colsep = "\t"
+  if a:0
+    let colsep = a:1
+  endif
+  return map(list#split(a:list, a:cols), 'join(v:val, "' . escape(colsep, '"') . '")')
+endfunction
+
+" split list into cols sublists and join with col and row seps
+" list#spread(list, cols, colsep, rowsep)
+function! list#spread(list, cols, ...)
+  let colsep = "\t"
+  let rowsep = "\n"
+  if a:0
+    if a:0 == 2
+      let colsep = a:1
+      let rowsep = a:2
+    else
+      let colsep = a:1
+    endif
+  endif
+  return join(list#lspread(a:list, a:cols, colsep), rowsep)
+endfunction
+
+" " map expr over each element of each sublist of list
+" function! list#lmap(list, expr)
+"   return map(a:list, 'map(v:val, ''' . a:expr . ''')')
+" endfunction
 
 function! list#shuffle(a)
   let b = deepcopy(a:a)

--- a/autoload/list.vim
+++ b/autoload/list.vim
@@ -65,9 +65,27 @@ function! list#zip(a, b, ...)
     exe "return r + a:b[" . n . ":]"
   endif
 endfunction "}}}1
-"
-" split list into count-element sublists
-function! list#split(list, count)
+
+" list#inject(list, init, funcref)
+function! list#inject(list, init, funcref)
+  if ! exists('*' . a:funcref)
+    echohl Error
+    echom 'vimple: list#inject(): Funcref ' . a:funcref . ' does not exist!'
+    echohl None
+    return a:init
+  elseif empty(a:list)
+    return a:init
+  else
+    let i  = a:list[0]
+    let r  = a:list[1:-1]
+    let v = call(a:funcref, [a:init, i])
+    return list#inject(r, v, a:funcref)
+  endif
+endf
+
+
+" partition list into count-element sublists
+function! list#partition(list, count)
   let lst = deepcopy(a:list)
   let len = len(lst)
   let cnt = a:count
@@ -83,18 +101,20 @@ function! list#split(list, count)
   return newlists
 endfunc
 
-" split list into cols sublists and join with colsep=\t
+" partition list into cols sublists and join with colsep=\t
 " list#lspread(list, cols, colsep="\t")
+" returns a list
 function! list#lspread(list, cols, ...)
   let colsep = "\t"
   if a:0
     let colsep = a:1
   endif
-  return map(list#split(a:list, a:cols), 'join(v:val, "' . escape(colsep, '"') . '")')
+  return map(list#partition(a:list, a:cols), 'join(v:val, "' . escape(colsep, '"') . '")')
 endfunction
 
-" split list into cols sublists and join with col and row seps
+" partition list into cols sublists and join with col and row seps
 " list#spread(list, cols, colsep, rowsep)
+" returns a string
 function! list#spread(list, cols, ...)
   let colsep = "\t"
   let rowsep = "\n"

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -68,9 +68,9 @@ function! overlay#close()
 endfunction
 
 function! overlay#select_line()
-  let fname = getline('.')
+  let line = getline('.')
   call overlay#close()
-  return fname
+  return line
 endfunction
 
 function! overlay#select_buffer()

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,6 +1,7 @@
  " TODO rename vfm variables.
 
 function! overlay#controller(...)
+  " TODO remove mappings and add them to VFM's actions.
   nnoremap <buffer> q :call overlay#close()<cr>
   nnoremap <buffer> cv :v//d<cr>
   if a:0
@@ -10,7 +11,7 @@ function! overlay#controller(...)
   endif
 endfunction
 
-function! overlay#show_list(list, ...)
+function! overlay#show(list, actions, ...)
   let s:altbuf = bufnr('#')
 
   let options = {
@@ -47,6 +48,10 @@ function! overlay#show_list(list, ...)
       call feedkeys('/')
     endif
   endif
+  call overlay#controller(a:actions)
+  " TODO how about evaluating an expression to decide if acting or not?
+  " TODO Should we allow specifying what action should be triggered?
+  " add "auto_act": "expr" and "auto_act_action": "expr" ?
   if g:vfm_auto_act_on_single_filter_result
     if line('$') == 1
       call feedkeys("\<enter>")
@@ -69,4 +74,18 @@ function! overlay#close()
   endif
 endfunction
 
+function! overlay#select_line()
+  let fname = getline('.')
+  call overlay#close()
+  return fname
+endfunction
 
+function! overlay#select_buffer()
+  let lines = getline(1,'$')
+  call overlay#close()
+  return lines
+endfunction
+
+function! overlay#command(cmd, actions, options)
+  call overlay#show(vimple#redir(a:cmd), a:actions, a:options)
+endfunction

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,0 +1,68 @@
+ " TODO rename vfm variables.
+function! overlay#overlay_controller(...)
+  nnoremap <buffer> q :call overlay#close_overlay()<cr>
+  nnoremap <buffer> cv :v//d<cr>
+  if a:0
+    for [key, act] in items(a:1)
+      exe 'nnoremap <buffer> ' . key . ' ' . act
+    endfor
+  endif
+endfunction
+
+function! overlay#show_list_overlay(files, ...)
+  let s:altbuf = bufnr('#')
+
+  let options = {'filter' : 1}
+  if a:0
+    if type(a:1) == type({})
+      call extend(options, a:1)
+    endif
+  endif
+
+  if g:vfm_use_split
+    hide noautocmd split
+  endif
+  hide noautocmd enew
+  let b:vfm_use_split = g:vfm_use_split
+  setlocal buftype=nofile
+  setlocal bufhidden=hide
+  setlocal noswapfile
+  let old_is = &incsearch
+  set incsearch
+  let old_hls = &hlsearch
+  set hlsearch
+  call append(0, a:files)
+  $
+  delete _
+  redraw
+  1
+  if options.filter
+    if exists(':Filter')
+      Filter
+    else
+      call feedkeys('/')
+    endif
+  endif
+  if g:vfm_auto_act_on_single_filter_result
+    if line('$') == 1
+      call feedkeys("\<enter>")
+    endif
+  endif
+endfunction
+
+function! overlay#close_overlay()
+  if b:vfm_use_split
+    let scratch_buf = bufnr('')
+    wincmd q
+    exe 'bwipe ' . scratch_buf
+  else
+    buffer #
+    bwipe #
+    if buflisted(s:altbuf)
+      exe 'buffer ' . s:altbuf
+      silent! buffer #
+    endif
+  endif
+endfunction
+
+

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,6 +1,6 @@
  " TODO rename vfm variables.
-function! overlay#overlay_controller(...)
-  nnoremap <buffer> q :call overlay#close_overlay()<cr>
+function! overlay#controller(...)
+  nnoremap <buffer> q :call overlay#close()<cr>
   nnoremap <buffer> cv :v//d<cr>
   if a:0
     for [key, act] in items(a:1)
@@ -9,7 +9,7 @@ function! overlay#overlay_controller(...)
   endif
 endfunction
 
-function! overlay#show_list_overlay(files, ...)
+function! overlay#show_list(files, ...)
   let s:altbuf = bufnr('#')
 
   let options = {'filter' : 1}
@@ -50,7 +50,7 @@ function! overlay#show_list_overlay(files, ...)
   endif
 endfunction
 
-function! overlay#close_overlay()
+function! overlay#close()
   if b:vfm_use_split
     let scratch_buf = bufnr('')
     wincmd q

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,9 +1,6 @@
  " TODO rename vfm variables.
 
 function! overlay#controller(...)
-  " TODO remove mappings and add them to VFM's actions.
-  nnoremap <buffer> q :call overlay#close()<cr>
-  nnoremap <buffer> cv :v//d<cr>
   if a:0
     for [key, act] in items(a:1)
       exe 'nnoremap <buffer> ' . key . ' ' . act

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,5 +1,3 @@
- " TODO rename vfm variables.
-
 function! overlay#controller(...)
   if a:0
     for [key, act] in items(a:1)
@@ -12,8 +10,9 @@ function! overlay#show(list, actions, ...)
   let s:altbuf = bufnr('#')
 
   let options = {
-        \ 'filter': 1,
-        \ 'use_split': 0,
+        \ 'filter'    : 1,
+        \ 'use_split' : 0,
+        \ 'auto_act'  : 0,
         \ }
   if a:0
     if type(a:1) == type({})
@@ -46,10 +45,7 @@ function! overlay#show(list, actions, ...)
     endif
   endif
   call overlay#controller(a:actions)
-  " TODO how about evaluating an expression to decide if acting or not?
-  " TODO Should we allow specifying what action should be triggered?
-  " add "auto_act": "expr" and "auto_act_action": "expr" ?
-  if g:vfm_auto_act_on_single_filter_result
+  if options.auto_act
     if line('$') == 1
       call feedkeys("\<enter>")
     endif

--- a/autoload/overlay.vim
+++ b/autoload/overlay.vim
@@ -1,4 +1,5 @@
  " TODO rename vfm variables.
+
 function! overlay#controller(...)
   nnoremap <buffer> q :call overlay#close()<cr>
   nnoremap <buffer> cv :v//d<cr>
@@ -9,21 +10,24 @@ function! overlay#controller(...)
   endif
 endfunction
 
-function! overlay#show_list(files, ...)
+function! overlay#show_list(list, ...)
   let s:altbuf = bufnr('#')
 
-  let options = {'filter' : 1}
+  let options = {
+        \ 'filter': 1,
+        \ 'use_split': 0,
+        \ }
   if a:0
     if type(a:1) == type({})
       call extend(options, a:1)
     endif
   endif
 
-  if g:vfm_use_split
+  if options.use_split
     hide noautocmd split
   endif
   hide noautocmd enew
-  let b:vfm_use_split = g:vfm_use_split
+  let b:overlay_use_split = options.use_split
   setlocal buftype=nofile
   setlocal bufhidden=hide
   setlocal noswapfile
@@ -31,7 +35,7 @@ function! overlay#show_list(files, ...)
   set incsearch
   let old_hls = &hlsearch
   set hlsearch
-  call append(0, a:files)
+  call append(0, a:list)
   $
   delete _
   redraw
@@ -51,7 +55,7 @@ function! overlay#show_list(files, ...)
 endfunction
 
 function! overlay#close()
-  if b:vfm_use_split
+  if b:overlay_use_split
     let scratch_buf = bufnr('')
     wincmd q
     exe 'bwipe ' . scratch_buf

--- a/demo/identsearch.vim
+++ b/demo/identsearch.vim
@@ -1,0 +1,34 @@
+" Are you bored with vanilla [I ?
+" Did the improvement above :help [i excite you only briefly?
+" Want a better experience?
+" Overlay is here for you.
+
+" In the overlay window:
+" You're prompted with a filter pattern. Use <esc> to cancel.
+" <enter> jumps to the current-line ident-search match
+" q closes the overlay without action
+
+function! IdentSearch()
+  try
+    let data = vimple#redir('norm! [I')
+  catch '^Vim\%((\a\+)\)\=:E389:'
+    echohl Warning
+    echom 'Could not find pattern'
+    echohl None
+    return
+  endtry
+  call overlay#show(
+        \  data
+        \, {
+        \    '<enter>' : ':call IdentSearchAccept()<cr>'
+        \  , 'q' : ':call overlay#close()<cr>'
+        \  }
+        \, {'filter'    : 1, 'use_split' : 1})
+endfunction
+
+function! IdentSearchAccept()
+  let num = matchstr(overlay#select_line(), '\d\+')
+  exe 'silent! norm! ' . num . "[\t"
+endfunction
+
+nnoremap [I :call IdentSearch()<cr>

--- a/demo/spellsuggest.vim
+++ b/demo/spellsuggest.vim
@@ -1,0 +1,32 @@
+" Are you bored with vanilla z= ?
+
+" In the overlay window:
+" <enter> replaces current word with word under cursor
+" q closes the overlay without action
+
+function! GetSuggestions(ident)
+  let spell = &spell
+  if ! spell
+    set spell
+  endif
+  let suggestions = list#lspread(spellsuggest(a:ident), 5)
+  if ! spell
+    set nospell
+  endif
+  return suggestions
+endfunction
+
+function! SpellSuggest(ident)
+  call overlay#show(
+        \  GetSuggestions(a:ident)
+        \, {'<enter>' : ':call SpellSuggestAccept()<cr>'}
+        \, {'filter'    : 0, 'use_split' : 1})
+endfunction
+
+nnoremap z= :call SpellSuggest(expand('<cword>'))<cr>
+
+function! SpellSuggestAccept()
+  let word = expand('<cword>')
+  call overlay#close()
+  exe 'norm! ciw' . word
+endfunction

--- a/demo/spellsuggest.vim
+++ b/demo/spellsuggest.vim
@@ -29,7 +29,11 @@ endfunction
 nnoremap z= :call SpellSuggest(expand('<cword>'))<cr>
 
 function! SpellSuggestAccept()
-  let word = expand('<cword>')
+  let reg_save = @/
+  let idx = strlen(substitute(getline('.')[:col('.')], "[^\t]", "", "g"))
+  let word_list = split(getline('.'), '\t')
+  let word = word_list[idx]
   call overlay#close()
-  exe 'norm! ciw' . word
+  execute 'normal! ciw' . word
+  let @/ = reg_save
 endfunction

--- a/demo/spellsuggest.vim
+++ b/demo/spellsuggest.vim
@@ -19,7 +19,10 @@ endfunction
 function! SpellSuggest(ident)
   call overlay#show(
         \  GetSuggestions(a:ident)
-        \, {'<enter>' : ':call SpellSuggestAccept()<cr>'}
+        \, {
+        \    '<enter>' : ':call SpellSuggestAccept()<cr>'
+        \  , 'q' : ':call overlay#close()<cr>'
+        \  }
         \, {'filter'    : 0, 'use_split' : 1})
 endfunction
 


### PR DESCRIPTION
When Vim's spellsuggest() offers two words for correction (for one misspelled word), the previous way would only accept the first word.
This fixes the issue by capturing the correct number of words suggested by Vim's spell checker.