### PR TITLE
Fix SpellSuggest demo.

### DIFF
--- a/demo/spellsuggest.vim
+++ b/demo/spellsuggest.vim
@@ -29,7 +29,11 @@ endfunction
 nnoremap z= :call SpellSuggest(expand('<cword>'))<cr>
 
 function! SpellSuggestAccept()
-  let word = expand('<cword>')
+  let reg_save = @/
+  let idx = strlen(substitute(getline('.')[:col('.')], "[^\t]", "", "g"))
+  let word_list = split(getline('.'), '\t')
+  let word = word_list[idx]
   call overlay#close()
-  exe 'norm! ciw' . word
+  execute 'normal! ciw' . word
+  let @/ = reg_save
 endfunction


### PR DESCRIPTION
When Vim's spellsuggest() offers two words for correction (for one misspelled word), the previous way would only accept the first word.

This fixes the issue by capturing the correct number of words suggested by Vim's spell checker.